### PR TITLE
Add --no-block flag for non-blocking CI mode

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -297,6 +297,9 @@ cat whatif-output.txt | bicep-whatif-advisor \
   --post-comment
 ```
 
+**Optional CI flags:**
+- `--no-block`: Report findings without failing pipeline (exit code 0 even if unsafe)
+
 ## Testing Strategy
 
 Required test fixtures in `tests/fixtures/`:

--- a/docs/guides/CLI_REFERENCE.md
+++ b/docs/guides/CLI_REFERENCE.md
@@ -108,6 +108,7 @@ az deployment group what-if ... | bicep-whatif-advisor --ci --diff-ref origin/ma
 | `--bicep-dir` | | `.` | Path to Bicep source files for additional context |
 | `--pr-title` | | Auto-detect | Pull request title for intent analysis (auto-fetched in GitHub Actions) |
 | `--pr-description` | | Auto-detect | Pull request description for intent analysis (auto-fetched in GitHub Actions) |
+| `--no-block` | | _(disabled)_ | Don't fail pipeline even if deployment is unsafe - only report findings (CI mode only) |
 
 ### Exit Codes
 


### PR DESCRIPTION
## Summary

This PR adds a `--no-block` flag to CI mode, enabling non-blocking deployment reviews that report findings without failing the pipeline.

## New Feature: `--no-block` Flag

Reports risk findings without failing the pipeline (exit code 0 even when unsafe).

**Use Cases:**
- **Informational reviews** - Get AI analysis without blocking deployments
- **Gradual rollout** - Start non-blocking, collect data, then gradually increase enforcement  
- **Soft gates** - Let teams review warnings but don't stop deployments
- **Multi-environment** - Block production but allow dev/staging to proceed

**Example:**
```bash
az deployment group what-if ... | bicep-whatif-advisor \
  --ci \
  --no-block \
  --post-comment

# Exit code: Always 0, even if unsafe
```

**Output:**
```
⚠️  Warning: Failed risk buckets: operations (pipeline not blocked due to --no-block)
ℹ️  CI mode: Reporting findings only (--no-block enabled)
```

## Changes

### Core Implementation
- **cli.py**: Added `--no-block` flag and exit code logic for non-blocking mode
- Shows warnings when risks detected but pipeline not blocked

### Documentation
- **CLI_REFERENCE.md**: New flag documentation
- **CICD_INTEGRATION.md**: Examples and best practices for `--no-block`
- **CLAUDE.md**: Updated project documentation

## Benefits

✅ **Progressive enforcement** - Start with `--no-block`, gradually increase strictness  
✅ **Flexible deployment gates** - Different enforcement per environment  
✅ **Risk visibility** - Get AI analysis and PR comments without blocking work  
✅ **Gradual adoption** - Teams can learn from findings before enforcing gates

## Example Workflows

### Progressive Enforcement Strategy

**Week 1-2: Non-blocking everywhere**
```yaml
- run: | bicep-whatif-advisor --ci --no-block
# Collect data, let teams learn from findings
```

**Week 3-4: Block production only**
```yaml
# Production: Strict gates
- run: | bicep-whatif-advisor --ci --drift-threshold high

# Dev/Staging: Still non-blocking
- run: | bicep-whatif-advisor --ci --no-block
```

**Week 5+: Full enforcement**
```yaml
# Production: Strict
- run: | bicep-whatif-advisor --ci --drift-threshold high

# Staging: Medium strictness
- run: | bicep-whatif-advisor --ci --drift-threshold medium

# Dev: Informational
- run: | bicep-whatif-advisor --ci --no-block
```

### Multi-Environment Example

```yaml
jobs:
  dev-review:
    steps:
      - run: | 
          az deployment group what-if ... | bicep-whatif-advisor \
            --ci \
            --no-block  # Informational only for dev

  production-review:
    steps:
      - run: |
          az deployment group what-if ... | bicep-whatif-advisor \
            --ci \
            --drift-threshold high  # Strict gates for production
```

## Testing

- [x] Verified `--no-block` flag appears in `--help` output
- [x] Updated all relevant documentation
- [x] Added usage examples for gradual enforcement strategies

## Related Issues

Addresses user request for non-blocking CI mode to support:
1. Informational reviews without blocking deployments
2. Gradual rollout of enforcement policies
3. Different risk tolerance per environment