### PR TITLE
Improve Azure DevOps permissions documentation

### DIFF
--- a/docs/guides/QUICKSTART.md
+++ b/docs/guides/QUICKSTART.md
@@ -68,6 +68,7 @@ az deployment group what-if \
 
 **For CI/CD pipelines:**
 - [CICD_INTEGRATION.md](./CICD_INTEGRATION.md) - Set up deployment gates in GitHub Actions, Azure DevOps, etc.
+  - **Note:** Azure DevOps requires build service permissions to post PR comments (see guide for setup)
 
 **Understand the AI:**
 - [RISK_ASSESSMENT.md](./RISK_ASSESSMENT.md) - How the three-bucket risk model works

--- a/docs/specs/09-PR-INTEGRATION.md
+++ b/docs/specs/09-PR-INTEGRATION.md
@@ -257,7 +257,15 @@ steps:
     SYSTEM_ACCESSTOKEN: $(System.AccessToken)
 ```
 
-**Permissions:** Build service must have "Contribute to pull requests" permission.
+**Permissions (CRITICAL):**
+The build service account must have **"Contribute to pull requests"** permission on the repository. Without this, API calls will fail with `403 Forbidden`.
+
+**How to grant:**
+1. Project Settings → Repositories → Security
+2. Find: `{ProjectName} Build Service ({OrgName})`
+3. Set **"Contribute to pull requests"** to **Allow**
+
+See [CICD_INTEGRATION.md - Azure DevOps Setup](../guides/CICD_INTEGRATION.md#step-1-configure-build-service-permissions) for detailed instructions.
 
 ### Error Handling
 


### PR DESCRIPTION
## Summary

Makes the Azure DevOps build service permissions requirement a prominent **Step 1** in the setup guide, preventing users from discovering it only after hitting 403 Forbidden errors.

## Changes

### 📝 CICD_INTEGRATION.md - Major restructure
- **Added Prerequisites section** - Lists all requirements before setup
- **Added Step 1: Configure Build Service Permissions** ⚠️ CRITICAL
  - Detailed instructions for granting "Contribute to pull requests" permission
  - Alternative method (disable job authorization scope)
  - Clear warning about 403 Forbidden without this step
- **Added Step 2: Create Variable Group** - Step-by-step instructions
- **Added Step 3: Create Pipeline File** - Complete working example
- **Updated troubleshooting** - Now references main setup steps instead of repeating

### 📄 09-PR-INTEGRATION.md (Spec)
- Enhanced permissions section with detailed explanation
- Added "CRITICAL" label to permissions requirement
- Included step-by-step grant instructions
- Added link to full CICD setup guide

### 🚀 QUICKSTART.md
- Added note about Azure DevOps requiring permissions setup
- Directs users to CICD guide for platform-specific requirements

## Why This Matters

**Before:** Users would set up their pipeline, run it on a PR, and get a cryptic 403 Forbidden error. Only then would they check troubleshooting and discover they needed to grant permissions.

**After:** Permissions setup is now the **first step** with a clear warning, preventing the issue entirely.

## Testing

Verified all documentation links work and formatting renders correctly.

---

🤖 Generated with Claude Code