### PR TITLE
Add Azure DevOps PR metadata auto-fetch via REST API

### DIFF
--- a/docs/guides/CICD_INTEGRATION.md
+++ b/docs/guides/CICD_INTEGRATION.md
@@ -385,6 +385,7 @@ stages:
 **That's it!** The tool automatically:
 - ✅ Detects Azure DevOps environment
 - ✅ Extracts PR ID and metadata
+- ✅ Fetches PR title and description via REST API
 - ✅ Sets git diff reference to PR target branch
 - ✅ Posts detailed PR comment
 - ✅ Blocks deployment if high risk detected
@@ -392,6 +393,7 @@ stages:
 **Auto-detection includes:**
 - CI mode enabled
 - PR ID from `SYSTEM_PULLREQUEST_PULLREQUESTID`
+- PR title/description via Azure DevOps REST API (requires `SYSTEM_ACCESSTOKEN`)
 - Diff reference from `SYSTEM_PULLREQUEST_TARGETBRANCH`
 - PR comments posted when `SYSTEM_ACCESSTOKEN` available
 
@@ -406,14 +408,22 @@ stages:
   --operations-threshold medium
 ```
 
-#### Manual PR Title/Description (Optional)
+#### PR Metadata Auto-Fetch
 
-If you want intent analysis in Azure DevOps:
+**Azure DevOps automatically fetches PR title and description** via the Azure DevOps REST API when `SYSTEM_ACCESSTOKEN` is available (automatically provided in Azure Pipelines).
+
+You'll see output like:
+```
+✅ Fetched PR title from Azure DevOps API: Add monitoring resources
+✅ Fetched PR description from Azure DevOps API (3 lines)
+```
+
+**Manual Override (Optional):** If you want to override the auto-fetched metadata:
 
 ```yaml
 | bicep-whatif-advisor \
-  --pr-title "$(System.PullRequest.Title)" \
-  --pr-description "$(System.PullRequest.Description)"
+  --pr-title "Custom title" \
+  --pr-description "Custom description"
 ```
 
 ---


### PR DESCRIPTION
## Summary

Implements automatic fetching of PR title and description from Azure DevOps REST API, providing feature parity with GitHub Actions for PR Intent Alignment risk assessment.

## Problem

Azure DevOps does not expose PR title and description as environment variables. Previously, users saw "No PR metadata provided" in the PR Intent Alignment risk bucket, even when the PR had a clear title and description.

## Solution

- Implemented `_fetch_ado_pr_metadata()` function to call Azure DevOps REST API
- Automatically fetches PR metadata when `SYSTEM_ACCESSTOKEN` is available (auto-provided in Azure Pipelines)
- Updated documentation to reflect new capability
- Added comprehensive error handling and logging

## Technical Details

**API Endpoint:**
```
GET {collection_uri}/{project}/_apis/git/repositories/{repo_id}/pullrequests/{pr_id}?api-version=7.0
```

**Required Environment Variables** (auto-provided in Azure Pipelines):
- `SYSTEM_ACCESSTOKEN` - Auth token
- `SYSTEM_COLLECTIONURI` - Organization URL
- `SYSTEM_TEAMPROJECT` - Project name
- `BUILD_REPOSITORY_ID` - Repository identifier

**Logging:**
```
✅ Fetched PR title from Azure DevOps API: Removed mexico factory IP from NSG
✅ Fetched PR description from Azure DevOps API (1 lines)
```

## Impact

- ✅ Fixes "No PR metadata provided" issue in Azure DevOps PRs
- ✅ Enables PR Intent Alignment risk assessment in Azure DevOps
- ✅ Feature parity with GitHub Actions
- ✅ No breaking changes - gracefully falls back if API call fails
- ✅ Manual `--pr-title` and `--pr-description` flags still work as overrides

## Testing

This should be tested in a real Azure DevOps pipeline to verify:
1. PR metadata is automatically fetched
2. Intent bucket shows proper risk assessment
3. Logging messages appear in pipeline output
4. Graceful fallback if API call fails

## Documentation Updates

- Updated `docs/specs/07-PLATFORM-DETECTION.md` - Removed "Future Enhancement" section, documented implementation
- Updated `docs/guides/CICD_INTEGRATION.md` - Added PR metadata auto-fetch section

## Related

This addresses the issue shown in the screenshot where PR Intent Alignment showed "Not evaluated" with "No PR metadata provided" despite the PR having a title and description.