### PR TITLE
Add UI improvements for CI/CD pipeline visibility

### DIFF
--- a/bicep_whatif_advisor/__init__.py
+++ b/bicep_whatif_advisor/__init__.py
@@ -1,3 +1,3 @@
 """bicep-whatif-advisor: Azure What-If deployment analyzer using LLMs."""
 
-__version__ = "1.8.0"
+__version__ = "1.9.0"

--- a/bicep_whatif_advisor/cli.py
+++ b/bicep_whatif_advisor/cli.py
@@ -9,7 +9,7 @@ from . import __version__
 from .input import read_stdin, InputError
 from .prompt import build_system_prompt, build_user_prompt
 from .providers import get_provider
-from .render import render_table, render_json, render_markdown
+from .render import render_table, render_json, render_markdown, print_banner
 from .ci.platform import detect_platform
 from .noise_filter import apply_noise_filtering
 
@@ -342,6 +342,10 @@ def main(
                 if has_token:
                     sys.stderr.write("💬 Auto-enabling PR comments (auth token detected)\n")
                     post_comment = True
+
+        # Print banner in CI/CD mode only
+        if ci:
+            print_banner()
 
         # Get diff content if CI mode
         diff_content = None

--- a/bicep_whatif_advisor/render.py
+++ b/bicep_whatif_advisor/render.py
@@ -8,6 +8,17 @@ from rich.table import Table
 from rich import box
 
 
+def print_banner() -> None:
+    """Print ASCII banner to identify tool output in CI/CD logs."""
+    banner = """
+┌─────────────────────────────────────────────────────────┐
+│  🛡️  BICEP WHAT-IF ADVISOR                              │
+│     AI-Powered Deployment Safety Review                 │
+└─────────────────────────────────────────────────────────┘
+"""
+    print(banner, file=sys.stderr)
+
+
 # Action symbols and colors
 ACTION_STYLES = {
     "Create": ("✅", "green"),
@@ -395,6 +406,8 @@ def render_markdown(data: dict, ci_mode: bool = False, custom_title: str = None,
 
     lines.append("")
     lines.append("</details>")
+    lines.append("")
+    lines.append("<br>")  # Add explicit spacing for Azure DevOps compatibility
     lines.append("")
 
     # Add collapsible noise section for low-confidence resources

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bicep-whatif-advisor"
-version = "1.8.0"
+version = "1.9.0"
 description = "AI-powered Azure Bicep What-If deployment advisor with automated safety reviews"
 readme = "README.md"
 requires-python = ">=3.8"


### PR DESCRIPTION
## Summary
- Add ASCII banner to help identify tool output in CI/CD logs
- Fix spacing issue between collapsible sections in Azure DevOps PR comments
- Bump version to 1.9.0

## Changes

### ASCII Banner (CI/CD Mode Only)
Added a shield-styled banner that displays at the start of analysis in CI/CD pipelines:
```
┌─────────────────────────────────────────────────────────┐
│  🛡️  BICEP WHAT-IF ADVISOR                              │
│     AI-Powered Deployment Safety Review                 │
└─────────────────────────────────────────────────────────┘
```
- Only displays when `--ci` flag is used or CI/CD platform is auto-detected
- Does not appear in interactive mode
- Makes it easy to find the tool's output when reviewing pipeline logs

### Azure DevOps Spacing Fix
- Added explicit `<br>` tag between "View changed resources" and "Potential Azure What-If Noise" sections
- Fixes spacing issue where ADO's markdown renderer doesn't add visual separation between collapsible sections
- Maintains compatibility with GitHub's markdown rendering

## Test Plan
- [x] Verify banner displays in CI mode
- [x] Verify banner does not display in interactive mode
- [x] Test markdown output renders correctly in both GitHub and ADO
- [x] Version bumped in both `__init__.py` and `pyproject.toml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)