### PR TITLE
Platform-dependent PR comment spacing (#26)

### DIFF
--- a/bicep_whatif_advisor/__init__.py
+++ b/bicep_whatif_advisor/__init__.py
@@ -1,3 +1,3 @@
 """bicep-whatif-advisor: Azure What-If deployment analyzer using LLMs."""
 
-__version__ = "2.0.0"
+__version__ = "2.1.0"

--- a/bicep_whatif_advisor/cli.py
+++ b/bicep_whatif_advisor/cli.py
@@ -579,6 +579,7 @@ def main(
                 custom_title=comment_title,
                 no_block=no_block,
                 low_confidence_data=low_confidence_data,
+                platform=platform_ctx.platform,
             )
             print(markdown)
 
@@ -602,6 +603,7 @@ def main(
                     custom_title=comment_title,
                     no_block=no_block,
                     low_confidence_data=low_confidence_data,
+                    platform=platform_ctx.platform,
                 )
                 _post_pr_comment(markdown, pr_url)
 

--- a/bicep_whatif_advisor/render.py
+++ b/bicep_whatif_advisor/render.py
@@ -337,6 +337,7 @@ def render_markdown(
     custom_title: str = None,
     no_block: bool = False,
     low_confidence_data: dict = None,
+    platform: str = None,
 ) -> str:
     """Render output as markdown table suitable for PR comments.
 
@@ -346,6 +347,7 @@ def render_markdown(
         custom_title: Custom title for the comment (default: "What-If Deployment Review")
         no_block: Append "(non-blocking)" to title if True
         low_confidence_data: Optional dict with low-confidence resources (potential noise)
+        platform: CI/CD platform ("github", "azuredevops", or None for default)
 
     Returns:
         Markdown-formatted string
@@ -431,8 +433,11 @@ def render_markdown(
     lines.append("")
     lines.append("</details>")
     lines.append("")
-    lines.append("<br>")  # Add explicit spacing for Azure DevOps compatibility
-    lines.append("")
+    # Azure DevOps needs an explicit <br> for spacing between collapsible sections;
+    # GitHub already adds sufficient spacing from the blank line alone.
+    if platform != "github":
+        lines.append("<br>")
+        lines.append("")
 
     # Add collapsible noise section for low-confidence resources
     if low_confidence_data and low_confidence_data.get("resources"):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bicep-whatif-advisor"
-version = "2.0.0"
+version = "2.1.0"
 description = "AI-powered Azure Bicep What-If deployment advisor with automated safety reviews"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -182,6 +182,57 @@ class TestRenderMarkdown:
         assert "Infrastructure Drift" in md
         assert "Risky Operations" in md
 
+    def test_github_no_br_between_details(self):
+        """GitHub platform should not include <br> between collapsible sections."""
+        data = {"resources": [], "overall_summary": ""}
+        low = {
+            "resources": [
+                {
+                    "resource_name": "noisy",
+                    "resource_type": "T",
+                    "action": "Modify",
+                    "confidence_reason": "noise",
+                }
+            ]
+        }
+        md = render_markdown(data, low_confidence_data=low, platform="github")
+        # Should have both details sections but no <br> between them
+        assert md.count("<details>") == 2
+        assert "<br>" not in md
+
+    def test_azuredevops_br_between_details(self):
+        """Azure DevOps platform should include <br> between collapsible sections."""
+        data = {"resources": [], "overall_summary": ""}
+        low = {
+            "resources": [
+                {
+                    "resource_name": "noisy",
+                    "resource_type": "T",
+                    "action": "Modify",
+                    "confidence_reason": "noise",
+                }
+            ]
+        }
+        md = render_markdown(data, low_confidence_data=low, platform="azuredevops")
+        assert md.count("<details>") == 2
+        assert "<br>" in md
+
+    def test_default_platform_br_between_details(self):
+        """Default (no platform) should include <br> for backward compatibility."""
+        data = {"resources": [], "overall_summary": ""}
+        low = {
+            "resources": [
+                {
+                    "resource_name": "noisy",
+                    "resource_type": "T",
+                    "action": "Modify",
+                    "confidence_reason": "noise",
+                }
+            ]
+        }
+        md = render_markdown(data, low_confidence_data=low)
+        assert "<br>" in md
+
     def test_footer_in_ci_mode(self):
         data = {"resources": [], "overall_summary": "", "verdict": {}}
         md = render_markdown(data, ci_mode=True)


### PR DESCRIPTION
## Summary
- The `<br>` tag between collapsible `<details>` sections created excessive spacing on GitHub while being needed for proper rendering on Azure DevOps
- Added a `platform` parameter to `render_markdown()` that conditionally omits the `<br>` tag when the platform is GitHub
- Both `render_markdown` call sites in `cli.py` now pass the auto-detected platform context
- Added 3 new unit tests covering GitHub, Azure DevOps, and default platform behavior
- Bumped version to 2.1.0

## Test plan
- [x] All 226 existing tests pass
- [x] 3 new tests verify platform-specific `<br>` behavior
- [ ] CI workflow passes on Python 3.9/3.11/3.13

🤖 Generated with [Claude Code](https://claude.com/claude-code)