### PR TITLE
Show all risk concerns via LLM summary

### DIFF
--- a/bicep_whatif_advisor/__init__.py
+++ b/bicep_whatif_advisor/__init__.py
@@ -1,3 +1,3 @@
 """bicep-whatif-advisor: Azure What-If deployment analyzer using LLMs."""
 
-__version__ = "2.5.1"
+__version__ = "2.5.2"

--- a/bicep_whatif_advisor/prompt.py
+++ b/bicep_whatif_advisor/prompt.py
@@ -134,6 +134,7 @@ def _build_ci_system_prompt(
         risk_buckets_schema.append(f'''    "{bucket_id}": {{
       "risk_level": "low|medium|high",
       "concerns": ["array of specific concerns"],
+      "concern_summary": "1-2 sentence summary of all concerns for display in a table cell, or 'None' if no concerns",
       "reasoning": "explanation of risk assessment"
     }}''')
 

--- a/bicep_whatif_advisor/render.py
+++ b/bicep_whatif_advisor/render.py
@@ -252,8 +252,7 @@ def _print_risk_bucket_summary(
         if bucket_data:
             risk_level = bucket_data.get("risk_level", "low")
             _, risk_color = RISK_STYLES.get(risk_level, ("?", "white"))
-            concerns = bucket_data.get("concerns", [])
-            concern_text = concerns[0] if concerns else "None"
+            concern_text = bucket_data.get("concern_summary") or "None"
 
             bucket_table.add_row(
                 bucket.display_name,
@@ -382,8 +381,7 @@ def render_markdown(
 
                 if bucket_data:
                     risk_level = bucket_data.get("risk_level", "low").capitalize()
-                    concerns = bucket_data.get("concerns", [])
-                    concern_text = concerns[0] if concerns else "None"
+                    concern_text = bucket_data.get("concern_summary") or "None"
                     lines.append(f"| {bucket.display_name} | {risk_level} | {concern_text} |")
 
             lines.append("")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bicep-whatif-advisor"
-version = "2.5.1"
+version = "2.5.2"
 description = "AI-powered Azure Bicep What-If deployment advisor with automated safety reviews"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -167,6 +167,7 @@ def sample_ci_response_unsafe():
             "operations": {
                 "risk_level": "high",
                 "concerns": ["Deletion of production database"],
+                "concern_summary": "Deletion of production database is a stateful resource deletion",
                 "reasoning": "Stateful resource deletion is high risk",
             },
         },


### PR DESCRIPTION
## Summary
- Previously only the first item from the `concerns` array was shown in the Key Concerns column of the risk assessment table
- Added `concern_summary` field to the LLM prompt schema so the LLM generates a 1-2 sentence natural language summary of all concerns per bucket
- Updated both Rich table and markdown renderers to use `concern_summary` instead of `concerns[0]`

## Test plan
- [x] All 297 tests pass
- [ ] Run CI mode against a deployment with multiple concerns per bucket and verify all are reflected in the Key Concerns column

🤖 Generated with [Claude Code](https://claude.com/claude-code)