### PR TITLE
Fix ADO spacing between collapsible PR comment sections

### DIFF
--- a/bicep_whatif_advisor/__init__.py
+++ b/bicep_whatif_advisor/__init__.py
@@ -1,3 +1,3 @@
 """bicep-whatif-advisor: Azure What-If deployment analyzer using LLMs."""
 
-__version__ = "2.5.2"
+__version__ = "2.5.3"

--- a/bicep_whatif_advisor/render.py
+++ b/bicep_whatif_advisor/render.py
@@ -469,6 +469,11 @@ def render_markdown(
         lines.append("")
         lines.append("</details>")
         lines.append("")
+        # Azure DevOps needs an explicit <br> for spacing between
+        # collapsible sections; GitHub handles it with blank lines.
+        if platform != "github":
+            lines.append("<br>")
+            lines.append("")
 
     # Raw What-If output (opt-in collapsible section)
     if whatif_content:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bicep-whatif-advisor"
-version = "2.5.2"
+version = "2.5.3"
 description = "AI-powered Azure Bicep What-If deployment advisor with automated safety reviews"
 readme = "README.md"
 requires-python = ">=3.8"


### PR DESCRIPTION
## Summary
- Adds `<br>` tag between the low-confidence noise section and raw What-If output section for Azure DevOps PR comments
- Uses the same conditional formatting pattern (`if platform != "github"`) already in place for the high-confidence → low-confidence section gap
- Bumps version to 2.5.3

## Test plan
- [x] All 297 tests pass
- [ ] Verify spacing in Azure DevOps PR comment renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)