### PR TITLE
Add pre-LLM resource block filtering

### DIFF
--- a/bicep_whatif_advisor/__init__.py
+++ b/bicep_whatif_advisor/__init__.py
@@ -1,3 +1,3 @@
 """bicep-whatif-advisor: Azure What-If deployment analyzer using LLMs."""
 
-__version__ = "3.4.0"
+__version__ = "3.5.0"

--- a/bicep_whatif_advisor/cli.py
+++ b/bicep_whatif_advisor/cli.py
@@ -531,20 +531,24 @@ def main(
                 sys.stderr.write(f"Error reading noise file: {e}\n")
                 sys.exit(2)
 
-        # Separate resource patterns (applied post-LLM) from property patterns (pre-LLM)
-        resource_noise_patterns, property_noise_patterns = extract_resource_patterns(noise_patterns)
+        # Separate resource patterns for post-LLM fallback reclassification
+        resource_noise_patterns, _ = extract_resource_patterns(noise_patterns)
 
         # Preserve original What-If content for --include-whatif (before noise filtering)
         original_whatif_content = whatif_content
 
-        if property_noise_patterns:
+        if noise_patterns:
             fuzzy_threshold = noise_threshold / 100.0
-            whatif_content, num_filtered = filter_whatif_text(
-                whatif_content, property_noise_patterns, fuzzy_threshold
+            whatif_content, num_lines, num_blocks = filter_whatif_text(
+                whatif_content, noise_patterns, fuzzy_threshold
             )
-            if num_filtered > 0:
+            if num_blocks > 0:
                 sys.stderr.write(
-                    f"🔕 Pre-filtered {num_filtered} known-noisy line(s) from What-If output\n"
+                    f"🔕 Pre-filtered {num_blocks} noisy resource block(s) from What-If output\n"
+                )
+            if num_lines > 0:
+                sys.stderr.write(
+                    f"🔕 Pre-filtered {num_lines} known-noisy line(s) from What-If output\n"
                 )
 
         # Get provider

--- a/bicep_whatif_advisor/data/builtin_noise_patterns.txt
+++ b/bicep_whatif_advisor/data/builtin_noise_patterns.txt
@@ -2,23 +2,24 @@
 # ─────────────────────────────────────────────────────────────────────────────
 # These patterns handle known Azure What-If false positives in two phases:
 #
-# 1. Property patterns (pre-LLM): Strip noisy property lines from raw What-If
+# 1. Resource patterns (pre-LLM): Remove entire matching resource blocks from
+#    raw What-If text BEFORE it is sent to the LLM. Also applied post-LLM as
+#    a fallback to demote any surviving matches to low confidence.
+# 2. Property patterns (pre-LLM): Strip noisy property lines from raw What-If
 #    text BEFORE it is sent to the LLM for analysis.
-# 2. Resource patterns (post-LLM): Demote matching resources to low confidence
-#    AFTER LLM analysis, so they appear in the "Potential Azure What-If Noise"
-#    section rather than being removed entirely.
 #
 # Pattern types:
 #   Plain text           — case-insensitive substring: keyword anywhere in line (pre-LLM)
 #   regex: <pattern>     — Python re.search(), case-insensitive (pre-LLM)
 #   fuzzy: <pattern>     — legacy fuzzy similarity (SequenceMatcher) (pre-LLM)
-#   resource: <type>     — demote to low confidence by ARM type substring (post-LLM)
-#   resource: <type>:Op  — demote only when operation matches (Modify, Create, etc.)
+#   resource: <type>     — remove block pre-LLM; also demote post-LLM fallback
+#   resource: <type>:Op  — remove/demote only when operation matches (Modify, Create, etc.)
 #
 # Plain-text, regex, and fuzzy patterns only apply to property-change lines
 # (indented 4+ spaces with a ~ / + / - change symbol).
 #
-# Resource patterns match the resource_type field from the LLM response.
+# Resource patterns match the ARM resource type in What-If block headers (pre-LLM)
+# and the resource_type field from the LLM response (post-LLM fallback).
 # Type matching is case-insensitive substring.
 #
 # To disable these built-ins: --no-builtin-patterns

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bicep-whatif-advisor"
-version = "3.4.0"
+version = "3.5.0"
 description = "AI-powered Azure Bicep What-If deployment advisor with automated safety reviews"
 readme = "README.md"
 requires-python = ">=3.8"


### PR DESCRIPTION
## Summary
- **Resource patterns now filter pre-LLM**: `resource:` patterns remove entire matching blocks from raw What-If text before LLM analysis (Phase 1), using deterministic ARM resource types from the What-If output instead of relying on inconsistent LLM-generated type strings
- **`filter_whatif_text()` returns 3-tuple**: `(filtered_text, property_lines_removed, resource_blocks_removed)` — CLI reports both counts separately via stderr
- **Post-LLM fallback preserved**: Resource patterns still demote surviving matches to low confidence after LLM analysis as a safety net
- **Version bump**: 3.4.0 → 3.5.0

## Test plan
- [x] All 413 tests pass (7 new tests added, 3 rewritten, ~14 updated for 3-tuple)
- [x] `ruff check .` and `ruff format --check .` clean
- [ ] CI tests pass on Python 3.9/3.11/3.13

🤖 Generated with [Claude Code](https://claude.com/claude-code)