### PR TITLE
Fix resource list showing summary row instead of individual resources

### DIFF
--- a/bicep_whatif_advisor/__init__.py
+++ b/bicep_whatif_advisor/__init__.py
@@ -1,3 +1,3 @@
 """bicep-whatif-advisor: Azure What-If deployment analyzer using LLMs."""
 
-__version__ = "3.5.4"
+__version__ = "3.5.5"

--- a/bicep_whatif_advisor/cli.py
+++ b/bicep_whatif_advisor/cli.py
@@ -689,25 +689,9 @@ def main(
                     ),
                 }
             else:
-                # Build a filtered What-If output containing only high-confidence resources
-                # We'll reconstruct a minimal What-If output from the high-confidence resources
-                # and re-prompt the LLM for accurate risk assessment
-                filtered_whatif_lines = ["Resource changes:"]
-                for resource in high_confidence_data.get("resources", []):
-                    # Reconstruct What-If format: "~ ResourceName"
-                    action_symbol = {
-                        "create": "+",
-                        "modify": "~",
-                        "delete": "-",
-                        "deploy": "=",
-                        "nochange": "*",
-                        "ignore": "x",
-                    }.get(resource.get("action", "").lower(), "~")
-
-                    filtered_whatif_lines.append(f"{action_symbol} {resource['resource_name']}")
-                    filtered_whatif_lines.append(f"  Summary: {resource['summary']}")
-
-                filtered_whatif_content = "\n".join(filtered_whatif_lines)
+                # Re-prompt the LLM with the already noise-filtered What-If
+                # content (real format, blocks already stripped) for accurate
+                # risk assessment based on high-confidence resources only.
 
                 # Re-build prompts with filtered data
                 filtered_system_prompt = build_system_prompt(
@@ -718,7 +702,7 @@ def main(
                     enabled_buckets=enabled_buckets,
                 )
                 filtered_user_prompt = build_user_prompt(
-                    whatif_content=filtered_whatif_content,
+                    whatif_content=whatif_content,
                     diff_content=diff_content,
                     bicep_content=bicep_content,
                     pr_title=pr_title,

--- a/bicep_whatif_advisor/noise_filter.py
+++ b/bicep_whatif_advisor/noise_filter.py
@@ -491,7 +491,12 @@ def filter_whatif_text(
         # No filtering needed — keep entire block
         result_lines.extend(block.lines)
 
-    result_lines.extend(epilogue)
+    # Only preserve the epilogue when no resource blocks were removed.
+    # The epilogue contains a summary like "Resource changes: 10 to modify."
+    # which becomes misleading when blocks have been stripped — the LLM sees
+    # the count mismatch and produces summary rows instead of individual resources.
+    if blocks_removed == 0:
+        result_lines.extend(epilogue)
     return "".join(result_lines), total_property_removed, blocks_removed, removed_resources
 
 

--- a/docs/issues/resource-list-regression.md
+++ b/docs/issues/resource-list-regression.md
@@ -1,0 +1,98 @@
+# Bug: Changed Resources Table Shows Summary Row Instead of Individual Resources
+
+## Status: Fixed
+
+## Description
+
+In CI mode PR comments, the "View changed resources" collapsible section displays a single summary row (e.g., "10 resources / Various / Modify / High") instead of listing each resource individually with its own name, type, action, and risk level.
+
+## Expected Behavior (v3.2.0)
+
+Each changed resource should appear as its own row in the table:
+
+| # | Resource | Type | Action | Risk | Summary |
+|---|----------|------|--------|------|---------|
+| 1 | myKeyVault | Microsoft.KeyVault/vaults | Modify | Low | Name updated |
+| 2 | myAppInsights | Microsoft.Insights/components | Modify | Low | Tags changed |
+| ... | ... | ... | ... | ... | ... |
+
+## Actual Behavior (v3.5.4)
+
+A single aggregated row appears instead:
+
+| # | Resource | Type | Action | Risk | Summary |
+|---|----------|------|--------|------|---------|
+| 1 | 10 resources | Various | Modify | High | What-If shows 10 resources being modified... |
+
+## Regression Window
+
+- **Last known good:** v3.2.0
+- **First known broken:** v3.5.0 (commit `96b0315` — pre-LLM resource block filtering)
+- **Worsened in:** v3.5.4 (commit `8c68b5d` — hollow Modify block suppression)
+
+## Reproduction
+
+Run the tool in CI mode against a deployment with multiple resource changes where most resources have only noisy property changes (e.g., etag, provisioningState). The more resources that get noise-filtered, the more likely the LLM produces a summary row.
+
+## Root Cause
+
+### Issue 1 (Primary): Stale epilogue after noise filtering
+
+**File:** `noise_filter.py:494`
+
+When `filter_whatif_text()` removes resource blocks (Phase 1 resource patterns and hollow Modify suppression), it strips the blocks from the output but **preserves the epilogue line verbatim**:
+
+```
+Resource changes: 1 to create, 9 to modify.
+```
+
+After filtering removes 9 of 10 blocks, the LLM receives What-If text that contains only 1 resource block but the epilogue still claims 10 changes. The LLM tries to reconcile this mismatch by producing a single summary row for the "missing" resources (e.g., "10 resources / Various / Modify").
+
+When ALL blocks are removed, the LLM receives just the preamble + epilogue with zero resource blocks, guaranteeing a summary-style response.
+
+**How it worked in v3.2.0:** Pre-LLM resource block removal didn't exist. All blocks were sent to the LLM, so the epilogue always matched the content. The LLM saw each resource and produced individual rows.
+
+### Issue 2 (Secondary): Lossy reconstruction in re-analysis path
+
+**File:** `cli.py:695-710`
+
+When re-analysis triggers (low-confidence resources detected in CI mode), the code reconstructs fake What-If content from the first LLM call's summaries instead of using the already-filtered `whatif_content` variable:
+
+```python
+filtered_whatif_lines = ["Resource changes:"]
+for resource in high_confidence_data.get("resources", []):
+    action_symbol = {...}.get(resource.get("action", "").lower(), "~")
+    filtered_whatif_lines.append(f"{action_symbol} {resource['resource_name']}")
+    filtered_whatif_lines.append(f"  Summary: {resource['summary']}")
+```
+
+This produces entries like:
+```
+~ storageAccount1
+  Summary: Modifies storage configuration
+```
+
+This doesn't match real What-If format (missing API version, indentation, property details), which may further confuse the LLM.
+
+Note: The re-analysis path only merges `risk_assessment` and `verdict` (lines 743-748), not `resources`, so this primarily affects risk assessment accuracy rather than the displayed resource list. However, if Issue 1 caused the initial LLM call to return a summary row, the re-analysis inherits that broken data.
+
+## Commits Involved
+
+| Commit | Version | Change | Impact |
+|--------|---------|--------|--------|
+| `96b0315` | v3.5.0 | Pre-LLM resource block filtering | Introduced block removal without epilogue update |
+| `8c68b5d` | v3.5.4 | Hollow Modify block suppression | More blocks removed, worsening the epilogue mismatch |
+
+## Proposed Fix
+
+### Fix 1 (Critical): Update or strip the epilogue after filtering
+
+In `noise_filter.py`, after resource blocks are removed, either:
+- **Option A:** Remove the epilogue line entirely from filtered output
+- **Option B:** Rewrite the epilogue to reflect actual remaining block counts
+
+Option A is simpler and sufficient — the LLM doesn't need the epilogue to analyze individual resources.
+
+### Fix 2 (Improvement): Use real What-If content in re-analysis
+
+In `cli.py:695-710`, replace the fake What-If reconstruction with the already-filtered `whatif_content` variable, which is real What-If format with noise already removed.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bicep-whatif-advisor"
-version = "3.5.4"
+version = "3.5.5"
 description = "AI-powered Azure Bicep What-If deployment advisor with automated safety reviews"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/tests/sample-bicep-deployment/main.bicep
+++ b/tests/sample-bicep-deployment/main.bicep
@@ -1,3 +1,5 @@
+// Trigger
+
 @description('Name of the Virtual Network')
 param vnetName string
 


### PR DESCRIPTION
## Summary

- Strip the What-If epilogue line (e.g., `"Resource changes: 10 to modify."`) from noise-filtered output when resource blocks have been removed. The stale epilogue caused the LLM to see a count mismatch and produce a single summary row instead of per-resource rows.
- Replace the lossy fake What-If reconstruction in the re-analysis path with the already-filtered real What-If content.
- Bump version to 3.5.5

## Root Cause

Pre-LLM noise filtering (introduced in v3.5.0) removes resource blocks but preserved the epilogue summary line verbatim. The LLM then saw "10 to modify" but only 0-1 actual resource blocks, and reconciled by producing a single summary row.

## Test plan

- [ ] Verify 414 tests pass locally (`pytest`)
- [ ] Run CI mode against a deployment with multiple noisy resources and confirm individual resource rows appear
- [ ] Verify epilogue is preserved when no blocks are removed (property-line-only filtering)

🤖 Generated with [Claude Code](https://claude.com/claude-code)