### PR TITLE
Fix verdict display ignoring threshold evaluation

### DIFF
--- a/bicep_whatif_advisor/__init__.py
+++ b/bicep_whatif_advisor/__init__.py
@@ -1,3 +1,3 @@
 """bicep-whatif-advisor: Azure What-If deployment analyzer using LLMs."""
 
-__version__ = "3.6.0"
+__version__ = "3.6.1"

--- a/bicep_whatif_advisor/cli.py
+++ b/bicep_whatif_advisor/cli.py
@@ -760,6 +760,38 @@ def main(
         if ci and enabled_buckets:
             high_confidence_data["_enabled_buckets"] = enabled_buckets
 
+        # CI mode: evaluate thresholds and override LLM verdict before rendering
+        is_safe = True
+        failed_buckets = []
+        if ci:
+            from .ci.risk_buckets import evaluate_risk_buckets
+
+            is_safe, failed_buckets, risk_assessment = evaluate_risk_buckets(
+                high_confidence_data,
+                enabled_buckets,
+                drift_threshold,
+                intent_threshold,
+                custom_thresholds=custom_thresholds,
+            )
+
+            # Override LLM verdict with threshold evaluation result
+            highest_bucket = failed_buckets[0] if failed_buckets else "none"
+            ra = high_confidence_data.get("risk_assessment", {})
+            highest_level = "low"
+            for bucket_id in enabled_buckets:
+                bucket_data = ra.get(bucket_id, {})
+                level = bucket_data.get("risk_level", "low")
+                level_idx = ["low", "medium", "high"].index(level)
+                if level_idx > ["low", "medium", "high"].index(highest_level):
+                    highest_level = level
+            existing_verdict = high_confidence_data.get("verdict", {})
+            high_confidence_data["verdict"] = {
+                "safe": is_safe,
+                "highest_risk_bucket": highest_bucket,
+                "overall_risk_level": highest_level,
+                "reasoning": existing_verdict.get("reasoning", ""),
+            }
+
         # Render output
         if format == "table":
             render_table(
@@ -784,18 +816,8 @@ def main(
             )
             print(markdown)
 
-        # CI mode: evaluate verdict and post comment
+        # CI mode: post comment and exit
         if ci:
-            from .ci.risk_buckets import evaluate_risk_buckets
-
-            is_safe, failed_buckets, risk_assessment = evaluate_risk_buckets(
-                high_confidence_data,
-                enabled_buckets,
-                drift_threshold,
-                intent_threshold,
-                custom_thresholds=custom_thresholds,
-            )
-
             # Post comment if requested
             if post_comment:
                 raw_whatif = original_whatif_content if include_whatif else None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bicep-whatif-advisor"
-version = "3.6.0"
+version = "3.6.1"
 description = "AI-powered Azure Bicep What-If deployment advisor with automated safety reviews"
 readme = "README.md"
 requires-python = ">=3.8"


### PR DESCRIPTION
## Summary
- The rendered output and PR comments were showing the LLM's raw `verdict.safe` field instead of the tool's threshold evaluation result
- This caused the verdict to display "SAFE" even when a risk level exceeded the configured threshold (e.g., medium risk with low threshold)
- Moved threshold evaluation **before** rendering and overrides the verdict in the data so output accurately reflects the threshold check
- Bump version to 3.6.1

## Test plan
- [x] All 414 tests pass
- [x] Lint and format checks pass
- [ ] Run against a deployment where LLM returns medium risk — verify verdict now shows UNSAFE with default low threshold

🤖 Generated with [Claude Code](https://claude.com/claude-code)