### PR TITLE
Change default risk threshold from low to medium

### DIFF
--- a/bicep_whatif_advisor/__init__.py
+++ b/bicep_whatif_advisor/__init__.py
@@ -1,3 +1,3 @@
 """bicep-whatif-advisor: Azure What-If deployment analyzer using LLMs."""
 
-__version__ = "3.6.1"
+__version__ = "3.6.2"

--- a/bicep_whatif_advisor/ci/agents.py
+++ b/bicep_whatif_advisor/ci/agents.py
@@ -131,7 +131,7 @@ def parse_agent_file(file_path: Path) -> Optional[RiskBucket]:
         )
 
     # Validate optional fields
-    default_threshold = str(metadata.get("default_threshold", "low")).lower()
+    default_threshold = str(metadata.get("default_threshold", "medium")).lower()
     if default_threshold not in _VALID_THRESHOLDS:
         raise ValueError(
             f"Agent file {file_path.name}: invalid"

--- a/bicep_whatif_advisor/ci/buckets.py
+++ b/bicep_whatif_advisor/ci/buckets.py
@@ -13,7 +13,7 @@ class RiskBucket:
     description: str  # Brief description for help text
     prompt_instructions: str  # LLM prompt instructions for this bucket
     optional: bool = False  # True if bucket can be omitted (like intent when no PR metadata)
-    default_threshold: str = "low"  # Default threshold for custom agents
+    default_threshold: str = "medium"  # Default threshold for custom agents
     custom: bool = False  # True for custom agents loaded from markdown files
     display: str = "summary"  # "summary", "table", or "list" — collapsible detail mode
     icon: str = ""  # Emoji for collapsible header (e.g., "💰")

--- a/bicep_whatif_advisor/ci/risk_buckets.py
+++ b/bicep_whatif_advisor/ci/risk_buckets.py
@@ -22,8 +22,8 @@ def _validate_risk_level(risk_level: str) -> str:
 def evaluate_risk_buckets(
     data: dict,
     enabled_buckets: List[str],
-    drift_threshold: str = "low",
-    intent_threshold: str = "low",
+    drift_threshold: str = "medium",
+    intent_threshold: str = "medium",
     custom_thresholds: Dict[str, str] = None,
 ) -> Tuple[bool, List[str], Dict[str, Any]]:
     """Evaluate enabled risk buckets and determine if deployment is safe.
@@ -86,7 +86,7 @@ def evaluate_risk_buckets(
             from .buckets import get_bucket
 
             bucket = get_bucket(bucket_id)
-            threshold = bucket.default_threshold if bucket else "low"
+            threshold = bucket.default_threshold if bucket else "medium"
 
         if _exceeds_threshold(risk_level, threshold):
             failed_buckets.append(bucket_id)

--- a/bicep_whatif_advisor/cli.py
+++ b/bicep_whatif_advisor/cli.py
@@ -252,14 +252,14 @@ def filter_by_confidence(data: dict) -> tuple[dict, dict]:
 @click.option(
     "--drift-threshold",
     type=click.Choice(["low", "medium", "high"], case_sensitive=False),
-    default="low",
+    default="medium",
     help="Fail pipeline if drift risk meets or exceeds this level"
     " (only applies if drift bucket enabled)",
 )
 @click.option(
     "--intent-threshold",
     type=click.Choice(["low", "medium", "high"], case_sensitive=False),
-    default="low",
+    default="medium",
     help="Fail pipeline if intent alignment risk meets or exceeds"
     " this level (only applies if intent bucket enabled)",
 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bicep-whatif-advisor"
-version = "3.6.1"
+version = "3.6.2"
 description = "AI-powered Azure Bicep What-If deployment advisor with automated safety reviews"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -109,11 +109,11 @@ class TestParseAgentFile:
         with pytest.raises(ValueError, match="threshold"):
             parse_agent_file(agent_file)
 
-    def test_default_threshold_defaults_to_low(self, tmp_path):
+    def test_default_threshold_defaults_to_medium(self, tmp_path):
         agent_file = tmp_path / "test.md"
         agent_file.write_text("---\nid: test\ndisplay_name: Test\n---\nBody")
         bucket = parse_agent_file(agent_file)
-        assert bucket.default_threshold == "low"
+        assert bucket.default_threshold == "medium"
 
     def test_optional_field(self, tmp_path):
         agent_file = tmp_path / "test.md"

--- a/tests/test_buckets.py
+++ b/tests/test_buckets.py
@@ -120,7 +120,7 @@ class TestRiskBucketFields:
             description="",
             prompt_instructions="",
         )
-        assert bucket.default_threshold == "low"
+        assert bucket.default_threshold == "medium"
 
     def test_custom_defaults_to_false(self):
         bucket = RiskBucket(

--- a/tests/test_risk_buckets.py
+++ b/tests/test_risk_buckets.py
@@ -205,8 +205,8 @@ class TestEvaluateRiskBuckets:
         assert is_safe is True
         assert failed == []
 
-    def test_custom_bucket_falls_back_to_default_high(self):
-        """Custom bucket without explicit threshold defaults to 'low'."""
+    def test_custom_bucket_falls_back_to_default_medium(self):
+        """Custom bucket without explicit threshold defaults to 'medium'."""
         data = {
             "risk_assessment": {
                 "custom_bucket": {
@@ -217,8 +217,8 @@ class TestEvaluateRiskBuckets:
             }
         }
         # No custom_thresholds provided, bucket not in built-in map
-        # Falls back to "low" default — medium exceeds low
-        is_safe, failed, ra = evaluate_risk_buckets(data, ["custom_bucket"], "low", "low")
+        # Falls back to "medium" default — medium meets medium threshold
+        is_safe, failed, ra = evaluate_risk_buckets(data, ["custom_bucket"], "medium", "medium")
         assert is_safe is False
         assert failed == ["custom_bucket"]
 


### PR DESCRIPTION
## Summary
- Changes the default `--drift-threshold` and `--intent-threshold` from `low` to `medium`
- The `low` default was too strict — it flagged deployments as unsafe even when the LLM assessed low risk (e.g., a clean deployment with no concerns)
- With `medium`: low risk passes, medium and high risk blocks
- Bumps version to 3.6.2

## Test plan
- [x] All 414 tests pass
- [x] Lint and format checks pass
- [ ] Run pipeline — low-risk environment should show SAFE, medium-risk should show UNSAFE

🤖 Generated with [Claude Code](https://claude.com/claude-code)