### PR TITLE
Fix custom agent incomplete findings and increase max tokens

### DIFF
--- a/bicep_whatif_advisor/__init__.py
+++ b/bicep_whatif_advisor/__init__.py
@@ -1,3 +1,3 @@
 """bicep-whatif-advisor: Azure What-If deployment analyzer using LLMs."""
 
-__version__ = "3.7.0"
+__version__ = "3.7.1"

--- a/bicep_whatif_advisor/prompt.py
+++ b/bicep_whatif_advisor/prompt.py
@@ -198,9 +198,9 @@ risk_level "low" with an empty concerns array."""
                 ]
             col_descriptions = ", ".join(f'"{c["key"]}" ({c["description"]})' for c in cols)
             bucket_text += f"""
-For the "{bucket_id}" bucket, also populate the "findings" array with per-resource details.
+For the "{bucket_id}" bucket, populate the "findings" array as described in the instructions above.
 Each finding should have {col_descriptions}.
-Include one finding per affected resource. If no issues found, return an empty array."""
+Include ALL checks or items described in the agent instructions, not just failing ones."""
         bucket_instructions_list.append(bucket_text)
 
     bucket_instructions = "\n".join(bucket_instructions_list)

--- a/bicep_whatif_advisor/providers/anthropic.py
+++ b/bicep_whatif_advisor/providers/anthropic.py
@@ -57,7 +57,7 @@ class AnthropicProvider(Provider):
             try:
                 response = client.messages.create(
                     model=self.model,
-                    max_tokens=4096,
+                    max_tokens=16384,
                     temperature=0,
                     system=system_prompt,
                     messages=[{"role": "user", "content": user_prompt}],

--- a/bicep_whatif_advisor/providers/azure_openai.py
+++ b/bicep_whatif_advisor/providers/azure_openai.py
@@ -68,6 +68,7 @@ class AzureOpenAIProvider(Provider):
                 response = client.chat.completions.create(
                     model=self.deployment,
                     temperature=0,
+                    max_tokens=16384,
                     messages=[
                         {"role": "system", "content": system_prompt},
                         {"role": "user", "content": user_prompt},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bicep-whatif-advisor"
-version = "3.7.0"
+version = "3.7.1"
 description = "AI-powered Azure Bicep What-If deployment advisor with automated safety reviews"
 readme = "README.md"
 requires-python = ">=3.8"


### PR DESCRIPTION
## Summary
- Fixed conflicting prompt instruction that told the LLM to include "one finding per affected resource" which overrode custom agent instructions requesting all checks regardless of compliance status
- Increased Anthropic max_tokens from 4096 to 16384 to prevent response truncation on complex agent outputs
- Added explicit max_tokens (16384) to Azure OpenAI provider which previously relied on model defaults

## Test plan
- [x] All 417 tests pass
- [ ] Run with custom agent that defines multiple checks and verify all checks appear in findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)