### PR TITLE
Scope resource listing constraint to resources array only

### DIFF
--- a/bicep_whatif_advisor/__init__.py
+++ b/bicep_whatif_advisor/__init__.py
@@ -1,3 +1,3 @@
 """bicep-whatif-advisor: Azure What-If deployment analyzer using LLMs."""
 
-__version__ = "3.7.2"
+__version__ = "3.7.3"

--- a/bicep_whatif_advisor/prompt.py
+++ b/bicep_whatif_advisor/prompt.py
@@ -252,16 +252,17 @@ Use your judgment - these are guidelines, not rigid patterns."""
 
 Respond with ONLY valid JSON matching this schema:
 
-IMPORTANT rules for the "resources" array:
-- List ONLY resources from <whatif_output>. Never add resources from other sections.
-- Each resource must be its own entry. NEVER group multiple resources into a single summary row.
-- If the What-If output contains no resource changes, return an empty array: "resources": [].
+IMPORTANT rules for the top-level "resources" array ONLY (not agent findings):
+- List ONLY resources that appear in <whatif_output>.
+- Each resource must be its own entry. NEVER group or summarize multiple resources.
+- If the What-If output has no resource changes, return "resources": [].
+- These rules do NOT apply to risk_assessment findings — agents control their own output.
 
 {{
   "resources": [
     {{
-      "resource_name": "string — the individual resource name from the What-If output",
-      "resource_type": "string — the Azure resource type from the What-If output",
+      "resource_name": "string — individual resource name from the What-If output",
+      "resource_type": "string — Azure resource type from the What-If output",
       "action": "string — Create, Modify, Delete, Deploy, NoChange, Ignore",
       "summary": "string — what this change does",
       "risk_level": "low|medium|high",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bicep-whatif-advisor"
-version = "3.7.2"
+version = "3.7.3"
 description = "AI-powered Azure Bicep What-If deployment advisor with automated safety reviews"
 readme = "README.md"
 requires-python = ">=3.8"


### PR DESCRIPTION
## Summary
- Clarified that the v3.7.2 resource listing constraint applies ONLY to the top-level `resources` array
- Added explicit carve-out: "These rules do NOT apply to risk_assessment findings — agents control their own output"
- Prevents the LLM from over-generalizing the constraint to limit what custom agents can reference from `<bicep_source>` or `<code_diff>` for their findings

## Problem
The v3.7.2 instruction "Never add resources from other sections" could cause the LLM to restrict custom agent findings that legitimately need to reference Bicep source (e.g., the SFI agent checks "The What-If output **or Bicep source** should show...").

## Test plan
- [x] All 417 tests pass
- [ ] Verify custom agent findings still reference Bicep source when applicable
- [ ] Verify resources array still only lists What-If resources

🤖 Generated with [Claude Code](https://claude.com/claude-code)